### PR TITLE
fix cnft_fulfill_buy  integration test, add canopy truncation

### DIFF
--- a/programs/mmm/src/instructions/cnft/sol_cnft_fulfill_buy.rs
+++ b/programs/mmm/src/instructions/cnft/sol_cnft_fulfill_buy.rs
@@ -134,7 +134,7 @@ pub fn handler<'info>(
 ) -> Result<()> {
     // let payer = &ctx.accounts.payer;
     let owner = &ctx.accounts.owner;
-    let pool = &mut ctx.accounts.pool;
+    let pool = &ctx.accounts.pool;
     // let sell_state = &mut ctx.accounts.sell_state;
     // let merkle_tree = &ctx.accounts.merkle_tree;
     // Remaining accounts are 1. (Optional) creator addresses and 2. Merkle proof path.

--- a/sdk/src/cnft.ts
+++ b/sdk/src/cnft.ts
@@ -1,6 +1,4 @@
-import {
-  MPL_BUBBLEGUM_PROGRAM_ID,
-} from '@metaplex-foundation/mpl-bubblegum';
+import { MPL_BUBBLEGUM_PROGRAM_ID } from '@metaplex-foundation/mpl-bubblegum';
 import { AccountMeta, PublicKey } from '@solana/web3.js';
 import { PREFIXES } from './constants';
 import { BN } from '@project-serum/anchor';


### PR DESCRIPTION
- fixes cnft fulfill buy test
- adds a default set of tree setup parameters that includes a canopy depth
- test utility methods added to handle canopy truncation
- renamed some fields to be more explicit about if full proof or truncated proof

note: not needed right away but might make sense to upgrade the anchor typescript client to @coral-xyz/anchor@0.29.0 to match the rust one. it's currently using @project-serum/anchor@0.25.0 which is pretty old.
